### PR TITLE
feat(supervisor): suspend an idle session, and reap a tree whose client is gone

### DIFF
--- a/.claude/skills/cdp-tools-contributing/SKILL.md
+++ b/.claude/skills/cdp-tools-contributing/SKILL.md
@@ -12,6 +12,7 @@ This skill is for working ON this repo's own source, not for using its tools to 
 - `npm run build` - `tsc` + dashboard build. Also runs a `postbuild` hook (`scripts/signal-supervisor.mjs`) that sends `SIGUSR2` to a running `mcp-supervisor` process (if any), so a live Claude Code session picks up the change without a manual `/mcp` reconnect.
 - `npm test` / `npm run test:run` - vitest. Tests are colocated as `*.test.ts` next to the code they cover.
 - `npm run build:verify` - build + `scripts/verify-mcp.js` + `scripts/measure-startup.mjs`. Run this before anything release-shaped. (`prepublishOnly` runs `test:run` **and** `build:verify`, but it is a backstop for a hand-rolled publish that should never happen - see below.)
+- `npm run stress:suspend` - drives the built supervisor as a real process to exercise idle suspend and orphan reaping: requests landing inside the teardown window, RSS/fd across many suspend cycles, a real Chrome and dev server actually being released, signal collisions, the kill escalation, and reaping across several trees. Needs a `npm run build` first, takes a few minutes, and is deliberately outside `npm test`. Run named scenarios (`-- race leak`), change the loop count (`-- --cycles=200`), or skip the slow real-Chrome one (`-- --skip=release`). Set `STRESS_VERBOSE=1` to see supervisor stderr. Touch it whenever `src/supervisor/` changes.
 
 ## Releasing
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,6 +69,38 @@ Create `.cdp-tools/config.json` to customize settings:
 
 The `defaultDebugPort` sets the starting port for Chrome debugging. If the port is in use, the next available port is used automatically.
 
+### Idle Sessions
+
+An editor window left open for days keeps its cdp-tools server alive, holding
+Chrome instances, dev servers and monitor buffers nobody is using. Two things
+stop that:
+
+- **Idle suspend.** After two hours with no request from the client, the server
+  releases what it privately holds - connections, the Chrome instances it
+  launched, monitor buffers - and exits. The supervisor stays connected, so the
+  MCP connection itself survives: the next tool call starts a fresh server. You
+  will need to relaunch Chrome (`launchChrome`). Managed dev servers keep
+  running and are reattached to, because they are shared between sessions on a
+  project and stopping them could pull one out from under another window.
+- **Orphan reaping.** When the client that launched cdp-tools is gone, the
+  server tree shuts itself down, rather than waiting for a stdin EOF that never
+  arrives when an `npm exec` wrapper is holding the pipe open.
+
+```json
+{
+  "session": {
+    "idleSuspendMinutes": 120,
+    "clientPollSeconds": 60
+  }
+}
+```
+
+Set `idleSuspendMinutes` to `0` to never suspend. Both values can also be set
+via `CDP_TOOLS_IDLE_SUSPEND_MINUTES` and `CDP_TOOLS_CLIENT_POLL_SECONDS`, which
+take precedence over the config file. Unlike most settings these are read by the
+supervisor at startup, so a change takes effect on the next reconnect rather
+than hot-reloading.
+
 ### Debug Logging
 
 Enable debug logging to track server operations:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,24 @@
 # Troubleshooting
 
+## Session Issues
+
+### Chrome closed itself and my connections are gone
+
+**Problem:** After a long break, connections are gone and Chrome is closed -
+but the MCP connection still works and dev servers are still running.
+
+**Cause:** The session was suspended. With no request from the client for
+`session.idleSuspendMinutes` (default 120), cdp-tools releases what it holds
+and exits; the supervisor stays connected and started a fresh server for your
+next call.
+
+**Solutions:**
+- Relaunch Chrome (`launchChrome`). Managed dev servers were left running and
+  the fresh server reattached to them, so there is nothing to restart there.
+- Raise or disable the threshold in `.cdp-tools/config.json`:
+  `{"session": {"idleSuspendMinutes": 0}}`. Read at supervisor startup, so it
+  applies from the next reconnect.
+
 ## Chrome Connection Issues
 
 ### "Chrome is already running on port X"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "stress:suspend": "node scripts/stress-suspend.mjs",
     "prepublishOnly": "npm run test:run && npm run build:verify",
     "version": "node scripts/sync-skill-version.mjs",
     "postversion": "git push && git push --tags"

--- a/scripts/stress-fixtures/fake-mcp-child.mjs
+++ b/scripts/stress-fixtures/fake-mcp-child.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * A minimal stand-in for the real MCP server (build/index.js), used by
+ * scripts/stress-suspend.mjs via MCP_SUPERVISOR_CHILD_SCRIPT.
+ *
+ * The suspend/resume state machine lives in the supervisor, not the server, so
+ * most of the stress scenarios only need a child that speaks JSON-RPC and can
+ * be told to misbehave on demand. Using this instead of the real server keeps
+ * a 200-cycle race loop to seconds instead of minutes, and makes "did the
+ * supervisor do the right thing" the only variable.
+ *
+ * Modes (argv, space separated):
+ *   ignore-suspend  - never exits on SIGUSR2, forcing the kill escalation path
+ *   slow-suspend=N  - takes N ms to release before exiting on SIGUSR2
+ *   grandchild      - spawns a detached sleeper in its process group, standing
+ *                     in for a Chrome or dev server the real child holds
+ *   slow-start=N    - waits N ms before answering anything
+ */
+import { spawn } from 'child_process';
+
+const modes = process.argv.slice(2);
+const has = (name) => modes.includes(name);
+const valueOf = (prefix, fallback) => {
+  const found = modes.find((m) => m.startsWith(`${prefix}=`));
+  return found ? Number(found.slice(prefix.length + 1)) : fallback;
+};
+
+const slowStartMs = valueOf('slow-start', 0);
+const slowSuspendMs = valueOf('slow-suspend', 0);
+
+let grandchild = null;
+if (has('grandchild')) {
+  // Inherits this process's group, so a group-wide SIGKILL should take it too.
+  grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 60000)'], { stdio: 'ignore' });
+  process.stderr.write(`[fake-child] grandchild pid ${grandchild.pid}\n`);
+}
+
+process.stderr.write(`[fake-child] ready (pid ${process.pid}, modes: ${modes.join(',') || 'none'})\n`);
+
+const send = (message) => process.stdout.write(JSON.stringify(message) + '\n');
+
+let buffer = '';
+process.stdin.on('data', async (chunk) => {
+  buffer += chunk.toString();
+  let index;
+  while ((index = buffer.indexOf('\n')) >= 0) {
+    const line = buffer.slice(0, index).trim();
+    buffer = buffer.slice(index + 1);
+    if (!line) continue;
+
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (message.id === undefined) continue; // notification
+
+    if (slowStartMs > 0) await new Promise((r) => setTimeout(r, slowStartMs));
+
+    if (message.method === 'initialize') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: { listChanged: true } },
+          serverInfo: { name: 'fake-mcp-child', version: '0.0.0' },
+        },
+      });
+    } else if (message.method === 'tools/list') {
+      send({ jsonrpc: '2.0', id: message.id, result: { tools: [{ name: 'noop', description: 'noop', inputSchema: { type: 'object' } }] } });
+    } else {
+      // Echo the pid so the harness can tell which child answered.
+      send({ jsonrpc: '2.0', id: message.id, result: { pid: process.pid } });
+    }
+  }
+});
+
+if (has('ignore-suspend')) {
+  process.on('SIGUSR2', () => {
+    process.stderr.write('[fake-child] ignoring SIGUSR2\n');
+  });
+} else {
+  process.on('SIGUSR2', () => {
+    setTimeout(() => {
+      if (grandchild) {
+        try {
+          process.kill(grandchild.pid, 'SIGTERM');
+        } catch {
+          // already gone
+        }
+      }
+      process.exit(0);
+    }, slowSuspendMs);
+  });
+}
+
+process.on('SIGTERM', () => process.exit(0));
+
+// The supervisor dying closes this pipe; without this the fixture would outlive
+// it as an orphan, which is exactly what the harness is meant to catch.
+process.stdin.on('end', () => process.exit(0));
+process.stdin.on('close', () => process.exit(0));
+
+// Stay alive until signalled.
+setInterval(() => {}, 60_000);

--- a/scripts/stress-suspend.mjs
+++ b/scripts/stress-suspend.mjs
@@ -1,0 +1,740 @@
+#!/usr/bin/env node
+/**
+ * Stress harness for idle suspend and orphan reaping (issue #138).
+ *
+ * The unit tests cover the state machine with injected fakes; this drives the
+ * real supervisor process over real stdio, with real signals and real timing,
+ * because the things most likely to break are the ones fakes cannot show you:
+ * a request landing inside the teardown window, a timer or fd that survives
+ * 200 cycles, a child that ignores its suspend signal while holding a browser.
+ *
+ * Not part of `npm test` - it spawns dozens of processes and takes minutes.
+ *
+ *   npm run stress:suspend                 # every scenario
+ *   npm run stress:suspend -- race leak    # named scenarios only
+ *   npm run stress:suspend -- --cycles=200 # longer race/leak runs
+ *   npm run stress:suspend -- --skip=release
+ *
+ * Scenarios use a sub-minute idle threshold: the supervisor takes fractional
+ * minutes in CDP_TOOLS_IDLE_SUSPEND_MINUTES, so 0.03 is 1.8 seconds and the
+ * two-hour production default never has to be waited out.
+ */
+import { spawn, execFileSync, execSync } from 'child_process';
+import { mkdtempSync, symlinkSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { connect } from 'net';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const SUPERVISOR = join(REPO_ROOT, 'build', 'mcp-supervisor.js');
+const FAKE_CHILD = join(__dirname, 'stress-fixtures', 'fake-mcp-child.mjs');
+
+// ---------------------------------------------------------------- utilities
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitUntil(predicate, { timeoutMs = 15_000, intervalMs = 50, what = 'condition' } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
+function childrenOf(pid) {
+  try {
+    return execFileSync('pgrep', ['-P', String(pid)], { encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(Number);
+  } catch {
+    return [];
+  }
+}
+
+function descendantsOf(pid) {
+  const direct = childrenOf(pid);
+  return direct.flatMap((child) => [child, ...descendantsOf(child)]);
+}
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === 'EPERM';
+  }
+}
+
+function rssKb(pid) {
+  try {
+    return Number(execFileSync('ps', ['-o', 'rss=', '-p', String(pid)], { encoding: 'utf-8' }).trim());
+  } catch {
+    return 0;
+  }
+}
+
+function fdCount(pid) {
+  try {
+    return execSync(`lsof -p ${pid} 2>/dev/null | wc -l`, { encoding: 'utf-8' }).trim() * 1;
+  } catch {
+    return 0;
+  }
+}
+
+/** The human-readable text of a tools/call answer, error or not. */
+function toolText(response) {
+  if (response?.error) return JSON.stringify(response.error);
+  return (response?.result?.content ?? []).map((part) => part.text ?? '').join(' ').trim() || JSON.stringify(response?.result ?? {});
+}
+
+/**
+ * Whether something is actually listening, tested by connecting rather than by
+ * binding: a server on `::` leaves `127.0.0.1` bindable on macOS, so a bind
+ * probe reports "free" for a port that is very much in use.
+ */
+function isListening(port) {
+  return new Promise((resolve) => {
+    const socket = connect({ port, host: '127.0.0.1' });
+    const settle = (answer) => {
+      socket.destroy();
+      resolve(answer);
+    };
+    socket.setTimeout(1000);
+    socket.once('connect', () => settle(true));
+    socket.once('timeout', () => settle(false));
+    socket.once('error', () => settle(false));
+  });
+}
+
+async function findFreePort(startPort) {
+  for (let port = startPort; port < startPort + 50; port++) {
+    if (!(await isListening(port))) return port;
+  }
+  throw new Error(`No free port in ${startPort}..${startPort + 50}`);
+}
+
+/**
+ * A supervisor under test, with the host side of its stdio wired up so the
+ * harness can act as Claude Code would.
+ */
+function startSupervisor({
+  idleMinutes = 0.03,
+  pollSeconds = 2,
+  childScript = FAKE_CHILD,
+  childModes = [],
+  suspendGraceMs,
+  cwd = tmpdir(),
+  parent = null, // { execPath, args } to launch under a fake client instead
+} = {}) {
+  const env = {
+    ...process.env,
+    CDP_TOOLS_IDLE_SUSPEND_MINUTES: String(idleMinutes),
+    CDP_TOOLS_CLIENT_POLL_SECONDS: String(pollSeconds),
+  };
+  if (childScript) env.MCP_SUPERVISOR_CHILD_SCRIPT = childScript;
+  if (suspendGraceMs !== undefined) env.CDP_TOOLS_SUSPEND_GRACE_MS = String(suspendGraceMs);
+
+  // Detached so it leads its own process group: stop() kills the group, and
+  // without this the group kill throws ESRCH and strands the supervisor's own
+  // (detached) child - a process-leak harness that leaks processes.
+  const proc = spawn(process.execPath, [SUPERVISOR, ...childModes], {
+    cwd,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    detached: true,
+  });
+
+  const stderr = [];
+  proc.stderr.on('data', (chunk) => {
+    const text = chunk.toString();
+    stderr.push(text);
+    if (process.env.STRESS_VERBOSE) process.stderr.write(`  [sup ${proc.pid}] ${text}`);
+  });
+
+  const pending = new Map();
+  const notifications = [];
+  let buffer = '';
+  proc.stdout.on('data', (chunk) => {
+    buffer += chunk.toString();
+    let index;
+    while ((index = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (message.id !== undefined && pending.has(message.id)) {
+        pending.get(message.id)(message);
+        pending.delete(message.id);
+      } else if (message.method) {
+        notifications.push(message);
+      }
+    }
+  });
+
+  let nextId = 1;
+  const request = (method, params = {}, { timeoutMs = 20_000 } = {}) => {
+    const id = nextId++;
+    const answered = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`No response to ${method} (id ${id}) within ${timeoutMs}ms`));
+      }, timeoutMs);
+      pending.set(id, (message) => {
+        clearTimeout(timer);
+        resolve(message);
+      });
+    });
+    proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    return answered;
+  };
+
+  const notify = (method, params = {}) => {
+    proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+  };
+
+  return {
+    proc,
+    pid: proc.pid,
+    stderr,
+    notifications,
+    request,
+    notify,
+    children: () => childrenOf(proc.pid),
+    stderrText: () => stderr.join(''),
+    async handshake() {
+      const result = await request('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'stress-harness', version: '1.0.0' },
+      });
+      notify('notifications/initialized');
+      return result;
+    },
+    async stop() {
+      if (!proc.killed) {
+        try {
+          process.kill(-proc.pid, 'SIGKILL');
+        } catch {
+          try {
+            proc.kill('SIGKILL');
+          } catch {
+            // already gone
+          }
+        }
+      }
+      await sleep(150);
+    },
+  };
+}
+
+const waitForSuspend = (supervisor, timeoutMs = 20_000) =>
+  waitUntil(() => supervisor.children().length === 0, { timeoutMs, what: 'the child to be suspended' });
+
+const waitForChild = (supervisor, timeoutMs = 20_000) =>
+  waitUntil(() => supervisor.children().length > 0, { timeoutMs, what: 'a child to be running' });
+
+/** Samples child count continuously so a transient double-spawn cannot hide. */
+function watchChildCount(supervisor, intervalMs = 20) {
+  let max = 0;
+  const timer = setInterval(() => {
+    max = Math.max(max, supervisor.children().length);
+  }, intervalMs);
+  return {
+    stop() {
+      clearInterval(timer);
+      return max;
+    },
+  };
+}
+
+// ---------------------------------------------------------------- scenarios
+
+/**
+ * 1. A request landing at every point around the teardown window. The child
+ *    takes 300ms to release, so requests are aimed across that window plus its
+ *    edges: too early is a normal call, too late is a normal resume, inside it
+ *    is the queue path that must not spawn a second child or drop the request.
+ */
+async function scenarioRace({ cycles }) {
+  const supervisor = startSupervisor({ idleMinutes: 0.03, childModes: ['slow-suspend=300'] });
+  const watcher = watchChildCount(supervisor);
+  const failures = [];
+  let hitTeardownWindow = 0;
+
+  try {
+    await supervisor.handshake();
+    await waitForChild(supervisor);
+
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      const suspendedAt = Date.now();
+      await waitForSuspend(supervisor);
+      const teardownStarted = Date.now() - suspendedAt;
+
+      // Aim across [-150ms, +350ms] relative to the moment the child went away.
+      const offset = Math.round((Math.random() - 0.3) * 500);
+      if (offset < 0) await sleep(Math.max(0, 300 + offset));
+      else await sleep(offset);
+      if (offset < 200) hitTeardownWindow++;
+
+      try {
+        const response = await supervisor.request('tools/call', { name: 'noop', arguments: {} }, { timeoutMs: 15_000 });
+        if (response.error) failures.push(`cycle ${cycle}: error ${JSON.stringify(response.error)}`);
+      } catch (err) {
+        failures.push(`cycle ${cycle}: ${err.message} (teardown started after ${teardownStarted}ms)`);
+      }
+    }
+
+    const maxChildren = watcher.stop();
+    if (maxChildren > 1) failures.push(`saw ${maxChildren} children alive at once`);
+
+    return {
+      passed: failures.length === 0,
+      detail: `${cycles} cycles, ~${hitTeardownWindow} aimed inside the teardown window, max children ${maxChildren}`,
+      failures,
+    };
+  } finally {
+    watcher.stop();
+    await supervisor.stop();
+  }
+}
+
+/**
+ * 2. Repeated suspend/resume, watching the supervisor's own footprint. Timers,
+ *    the NDJSON buffer and the queued-line array all live across cycles, so a
+ *    leak here would show as steady growth rather than a crash.
+ */
+async function scenarioLeak({ cycles }) {
+  const supervisor = startSupervisor({ idleMinutes: 0.03 });
+  const samples = [];
+
+  try {
+    await supervisor.handshake();
+    await waitForChild(supervisor);
+
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      await waitForSuspend(supervisor);
+      const response = await supervisor.request('tools/call', { name: 'noop', arguments: {} });
+      if (response.error) throw new Error(`cycle ${cycle}: ${JSON.stringify(response.error)}`);
+      if (cycle % 10 === 0 || cycle === cycles - 1) {
+        samples.push({ cycle, rssKb: rssKb(supervisor.pid), fds: fdCount(supervisor.pid) });
+      }
+    }
+
+    const first = samples[0];
+    const last = samples.at(-1);
+    const rssGrowthKb = last.rssKb - first.rssKb;
+    const fdGrowth = last.fds - first.fds;
+    const failures = [];
+    // Node's heap wanders; anything under ~8MB across this many cycles is noise.
+    if (rssGrowthKb > 8192) failures.push(`RSS grew ${Math.round(rssGrowthKb / 1024)}MB across ${cycles} cycles`);
+    if (fdGrowth > 10) failures.push(`fd count grew by ${fdGrowth} across ${cycles} cycles`);
+
+    return {
+      passed: failures.length === 0,
+      detail: samples.map((s) => `c${s.cycle}:${Math.round(s.rssKb / 1024)}MB/${s.fds}fd`).join(' '),
+      failures,
+    };
+  } finally {
+    await supervisor.stop();
+  }
+}
+
+/**
+ * 3. What a suspend does and does not release, checked against the real server
+ *    rather than a fixture: the Chrome it launched must be gone, and a managed
+ *    dev server must still be running - dev servers are shared between
+ *    sessions, so suspending must never take one down.
+ */
+async function scenarioRelease() {
+  if (!existsSync(join(REPO_ROOT, 'build', 'index.js'))) {
+    return { skipped: true, detail: 'build/index.js missing - run npm run build first' };
+  }
+
+  const workDir = mkdtempSync(join(tmpdir(), 'cdp-stress-release-'));
+  // A file rather than `node -e`: the command is handed to a shell, and the
+  // quoting a one-liner needs does not survive that intact.
+  const devServerScript = join(workDir, 'stress-dev-server.mjs');
+  // Long enough to get Chrome and a dev server up before the clock runs out.
+  const supervisor = startSupervisor({ idleMinutes: 0.5, childScript: null, cwd: workDir });
+  // Picked from what is actually free: a fixed port turns a leftover process
+  // from an earlier aborted run into a confusing EADDRINUSE failure here.
+  const devServerPort = await findFreePort(39_517);
+  const failures = [];
+
+  try {
+    writeFileSync(
+      devServerScript,
+      `import { createServer } from 'http';\n` +
+        `createServer((req, res) => res.end('ok')).listen(${devServerPort}, () => console.log('listening on ${devServerPort}'));\n`
+    );
+
+    await supervisor.handshake();
+    await waitForChild(supervisor);
+
+    const launch = await supervisor.request(
+      'tools/call',
+      { name: 'launchChrome', arguments: { reference: 'suspend stress release', headless: true } },
+      { timeoutMs: 60_000 }
+    );
+    // A failing tool answers with a result carrying isError, not a JSON-RPC
+    // error - checking only the latter would call a broken setup a pass.
+    // A failing launchChrome used to SKIP, which meant a regression that broke
+    // Chrome entirely still exited 0 - the scenario exists to prove Chrome is
+    // released, so it has to fail when Chrome never starts.
+    if (launch.error || launch.result?.isError) {
+      failures.push(`launchChrome failed: ${toolText(launch).slice(0, 200)}`);
+      return { passed: false, detail: 'could not launch Chrome to release', failures };
+    }
+
+    const startServer = await supervisor.request(
+      'tools/call',
+      {
+        name: 'server',
+        arguments: {
+          action: 'start',
+          id: 'stress-release-server',
+          command: `node ${devServerScript}`,
+          cwd: workDir,
+          port: devServerPort,
+        },
+      },
+      { timeoutMs: 60_000 }
+    );
+    if (startServer.error || startServer.result?.isError) {
+      failures.push(`server start failed: ${toolText(startServer).slice(0, 300)}`);
+    }
+
+    await waitUntil(() => isListening(devServerPort), { timeoutMs: 20_000, what: 'the dev server to listen' });
+
+    const chromePids = descendantsOf(supervisor.children()[0]).filter((pid) => {
+      try {
+        return execFileSync('ps', ['-o', 'command=', '-p', String(pid)], { encoding: 'utf-8' }).includes('remote-debugging-port');
+      } catch {
+        return false;
+      }
+    });
+
+    await waitForSuspend(supervisor, 60_000);
+    await sleep(2000); // let the OS finish reaping what the child signalled
+
+    // No pids found means the assertion below proves nothing - that is a
+    // broken test, not a pass.
+    if (chromePids.length === 0) failures.push('found no Chrome processes to check - the release assertion would be vacuous');
+    for (const pid of chromePids) {
+      if (isAlive(pid)) failures.push(`Chrome pid ${pid} survived the suspend`);
+    }
+    // Dev servers are shared, so a suspend must leave them alone. This is the
+    // assertion that would catch a regression back to stopping them.
+    if (!(await isListening(devServerPort))) failures.push(`dev server on ${devServerPort} was stopped by the suspend`);
+    if (supervisor.children().length > 0) failures.push('child still running after suspend');
+
+    // And the connection itself must still work.
+    const resumed = await supervisor.request('tools/list', {}, { timeoutMs: 60_000 });
+    if (resumed.error || !resumed.result?.tools?.length) failures.push('tools/list did not answer after resume');
+
+    return {
+      passed: failures.length === 0,
+      detail: `${chromePids.length} chrome pid(s) released, dev server on ${devServerPort} left running`,
+      failures,
+    };
+  } finally {
+    await supervisor.stop();
+    // A scenario that aborts mid-way must not leave a listener behind for the
+    // next run to trip over.
+    try {
+      execSync(`pkill -f ${devServerScript} 2>/dev/null`, { stdio: 'ignore' });
+    } catch {
+      // best effort
+    }
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * 4. Signals arriving at the worst possible moment: a rebuild trigger while
+ *    the child is mid-teardown, a shutdown in the same window, and a child
+ *    that is SIGKILLed exactly as the suspend lands. None may leave a second
+ *    child, a crash-respawn storm, or an unanswered request behind.
+ */
+async function scenarioSignals() {
+  const failures = [];
+
+  // (a) SIGUSR2 (rebuild) during the teardown window.
+  {
+    const supervisor = startSupervisor({ idleMinutes: 0.03, childModes: ['slow-suspend=800'] });
+    const watcher = watchChildCount(supervisor);
+    try {
+      await supervisor.handshake();
+      await waitForChild(supervisor);
+      await waitUntil(() => supervisor.stderrText().includes('Suspending idle child'), { timeoutMs: 20_000, what: 'the suspend to start' });
+      process.kill(supervisor.pid, 'SIGUSR2');
+      await sleep(2000);
+
+      const response = await supervisor.request('tools/call', { name: 'noop', arguments: {} }, { timeoutMs: 20_000 });
+      if (response.error) failures.push(`(a) rebuild-during-suspend: ${JSON.stringify(response.error)}`);
+      const maxChildren = watcher.stop();
+      if (maxChildren > 1) failures.push(`(a) rebuild-during-suspend spawned ${maxChildren} children`);
+    } catch (err) {
+      failures.push(`(a) rebuild-during-suspend: ${err.message}`);
+    } finally {
+      watcher.stop();
+      await supervisor.stop();
+    }
+  }
+
+  // (b) SIGTERM during the teardown window - must exit cleanly, leaving nothing.
+  {
+    const supervisor = startSupervisor({ idleMinutes: 0.03, childModes: ['slow-suspend=800'] });
+    try {
+      await supervisor.handshake();
+      await waitForChild(supervisor);
+      const childPid = supervisor.children()[0];
+      await waitUntil(() => supervisor.stderrText().includes('Suspending idle child'), { timeoutMs: 20_000, what: 'the suspend to start' });
+      process.kill(supervisor.pid, 'SIGTERM');
+
+      await waitUntil(() => !isAlive(supervisor.pid), { timeoutMs: 15_000, what: 'the supervisor to exit' });
+      if (childPid && isAlive(childPid)) failures.push('(b) shutdown-during-suspend left the child alive');
+    } catch (err) {
+      failures.push(`(b) shutdown-during-suspend: ${err.message}`);
+    } finally {
+      await supervisor.stop();
+    }
+  }
+
+  // (c) child SIGKILLed exactly as the suspend lands - a kill the supervisor
+  //     did not ask for, arriving where it expects a deliberate exit.
+  {
+    const supervisor = startSupervisor({ idleMinutes: 0.03, childModes: ['slow-suspend=500'] });
+    const watcher = watchChildCount(supervisor);
+    try {
+      await supervisor.handshake();
+      await waitForChild(supervisor);
+      const childPid = supervisor.children()[0];
+      await waitUntil(() => supervisor.stderrText().includes('Suspending idle child'), { timeoutMs: 20_000, what: 'the suspend to start' });
+      try {
+        process.kill(childPid, 'SIGKILL');
+      } catch {
+        // it beat us to it
+      }
+      await sleep(2500);
+
+      const response = await supervisor.request('tools/call', { name: 'noop', arguments: {} }, { timeoutMs: 20_000 });
+      if (response.error) failures.push(`(c) child-killed-during-suspend: ${JSON.stringify(response.error)}`);
+      const maxChildren = watcher.stop();
+      if (maxChildren > 1) failures.push(`(c) child-killed-during-suspend spawned ${maxChildren} children`);
+    } catch (err) {
+      failures.push(`(c) child-killed-during-suspend: ${err.message}`);
+    } finally {
+      watcher.stop();
+      await supervisor.stop();
+    }
+  }
+
+  return { passed: failures.length === 0, detail: '3 collisions: rebuild, shutdown, child SIGKILL', failures };
+}
+
+/**
+ * 5. A child that ignores its suspend signal while holding a grandchild - the
+ *    stand-in for a server wedged with a browser attached. The supervisor must
+ *    escalate rather than wait forever, and the grandchild must not survive.
+ */
+async function scenarioEscalation() {
+  const supervisor = startSupervisor({
+    idleMinutes: 0.03,
+    childModes: ['ignore-suspend', 'grandchild'],
+    suspendGraceMs: 2000,
+  });
+  const failures = [];
+
+  try {
+    await supervisor.handshake();
+    await waitForChild(supervisor);
+    const childPid = supervisor.children()[0];
+    const grandchildren = descendantsOf(childPid);
+
+    const startedAt = Date.now();
+    await waitForSuspend(supervisor, 30_000);
+    const escalationMs = Date.now() - startedAt;
+
+    await sleep(1000);
+    if (isAlive(childPid)) failures.push(`child ${childPid} survived escalation`);
+    for (const pid of grandchildren) {
+      if (isAlive(pid)) failures.push(`grandchild ${pid} survived escalation`);
+    }
+
+    const response = await supervisor.request('tools/call', { name: 'noop', arguments: {} }, { timeoutMs: 20_000 });
+    if (response.error) failures.push(`resume after escalation: ${JSON.stringify(response.error)}`);
+
+    return {
+      passed: failures.length === 0,
+      detail: `escalated and resumed in ${escalationMs}ms (grace 2000ms), ${grandchildren.length} grandchild(ren) checked`,
+      failures,
+    };
+  } finally {
+    await supervisor.stop();
+  }
+}
+
+/**
+ * 6. Orphan reaping across a fan-out: one client, several supervisors. Nothing
+ *    may die while the client lives, and everything must die once it doesn't -
+ *    which is the failure that leaves 500MB of week-old trees behind.
+ */
+async function scenarioReaper() {
+  const TREES = 6;
+  const POLL_SECONDS = 2;
+  const workDir = mkdtempSync(join(tmpdir(), 'cdp-stress-reaper-'));
+  // The watcher walks past node/npm/shell ancestors, so a fake client has to
+  // be something else: a differently-named symlink to Node reads as its own
+  // program in `ps`, the way `claude` or an IDE helper does.
+  const fakeClient = join(workDir, 'stress-fake-client');
+  symlinkSync(process.execPath, fakeClient);
+
+  const launcher = `
+    const { spawn } = require('child_process');
+    const kids = [];
+    for (let i = 0; i < ${TREES}; i++) {
+      kids.push(spawn(process.argv[0], [${JSON.stringify(SUPERVISOR)}], {
+        stdio: ['pipe', 'pipe', 'ignore'],
+        env: { ...process.env,
+          MCP_SUPERVISOR_CHILD_SCRIPT: ${JSON.stringify(FAKE_CHILD)},
+          CDP_TOOLS_IDLE_SUSPEND_MINUTES: '0',
+          CDP_TOOLS_CLIENT_POLL_SECONDS: '${POLL_SECONDS}' },
+      }));
+    }
+    process.stdout.write(kids.map(k => k.pid).join(',') + '\\n');
+    setInterval(() => {}, 60000);
+  `;
+
+  const client = spawn(fakeClient, ['-e', launcher], { stdio: ['ignore', 'pipe', 'ignore'] });
+  const failures = [];
+
+  try {
+    const supervisorPids = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('fake client never reported its supervisors')), 15_000);
+      client.stdout.once('data', (chunk) => {
+        clearTimeout(timer);
+        resolve(chunk.toString().trim().split(',').map(Number));
+      });
+    });
+
+    // Give every tree a child, then confirm three polls pass with none reaped:
+    // a watcher that fires while the client is alive is worse than none.
+    await sleep(1500);
+    const allPids = supervisorPids.flatMap((pid) => [pid, ...descendantsOf(pid)]);
+    await sleep(POLL_SECONDS * 3 * 1000);
+    const falsePositives = allPids.filter((pid) => !isAlive(pid));
+    if (falsePositives.length > 0) failures.push(`${falsePositives.length} process(es) reaped while the client was alive`);
+
+    process.kill(client.pid, 'SIGKILL');
+    const killedAt = Date.now();
+
+    try {
+      await waitUntil(() => allPids.every((pid) => !isAlive(pid)), {
+        timeoutMs: POLL_SECONDS * 4 * 1000,
+        intervalMs: 200,
+        what: 'every orphaned process to be reaped',
+      });
+    } catch (err) {
+      const survivors = allPids.filter(isAlive);
+      failures.push(`${survivors.length}/${allPids.length} process(es) survived the client: ${survivors.join(', ')}`);
+      for (const pid of survivors) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // best effort cleanup
+        }
+      }
+    }
+
+    return {
+      passed: failures.length === 0,
+      detail: `${TREES} trees / ${allPids.length} processes, reaped ${Date.now() - killedAt}ms after the client died (poll ${POLL_SECONDS}s)`,
+      failures,
+    };
+  } finally {
+    try {
+      process.kill(client.pid, 'SIGKILL');
+    } catch {
+      // already gone
+    }
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+// -------------------------------------------------------------------- runner
+
+const SCENARIOS = {
+  race: { run: scenarioRace, description: 'requests landing across the teardown window' },
+  leak: { run: scenarioLeak, description: 'supervisor RSS/fd across many suspend cycles' },
+  release: { run: scenarioRelease, description: 'real Chrome released, shared dev server left alone' },
+  signals: { run: scenarioSignals, description: 'rebuild/shutdown/child-kill during teardown' },
+  escalation: { run: scenarioEscalation, description: 'child ignoring the suspend signal' },
+  reaper: { run: scenarioReaper, description: 'orphan reaping across several trees' },
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cycles = Number(args.find((a) => a.startsWith('--cycles='))?.split('=')[1] ?? 40);
+  const skip = (args.find((a) => a.startsWith('--skip='))?.split('=')[1] ?? '').split(',').filter(Boolean);
+  const named = args.filter((a) => !a.startsWith('--'));
+
+  const selected = (named.length > 0 ? named : Object.keys(SCENARIOS)).filter((name) => !skip.includes(name));
+  const unknown = selected.filter((name) => !SCENARIOS[name]);
+  if (unknown.length > 0) {
+    console.error(`Unknown scenario(s): ${unknown.join(', ')}\nAvailable: ${Object.keys(SCENARIOS).join(', ')}`);
+    process.exit(2);
+  }
+
+  if (!existsSync(SUPERVISOR)) {
+    console.error(`Missing ${SUPERVISOR} - run npm run build first.`);
+    process.exit(2);
+  }
+
+  console.log(`Stress: ${selected.join(', ')} (cycles=${cycles})\n`);
+
+  const results = [];
+  for (const name of selected) {
+    const startedAt = Date.now();
+    process.stdout.write(`▸ ${name}: ${SCENARIOS[name].description} ... `);
+    let result;
+    try {
+      result = await SCENARIOS[name].run({ cycles });
+    } catch (err) {
+      result = { passed: false, failures: [err.message], detail: 'threw' };
+    }
+    const seconds = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+    if (result.skipped) {
+      console.log(`SKIP (${seconds}s)\n    ${result.detail}`);
+    } else if (result.passed) {
+      console.log(`PASS (${seconds}s)\n    ${result.detail}`);
+    } else {
+      console.log(`FAIL (${seconds}s)\n    ${result.detail}`);
+      for (const failure of result.failures ?? []) console.log(`    ✗ ${failure}`);
+    }
+    results.push({ name, ...result });
+  }
+
+  const failed = results.filter((r) => !r.passed && !r.skipped);
+  const skipped = results.filter((r) => r.skipped);
+  console.log(
+    `\n${results.length - failed.length - skipped.length} passed, ${failed.length} failed, ${skipped.length} skipped`
+  );
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,9 +220,30 @@ export interface ToolsConfig {
   disabled: string[];  // Tools to disable (takes priority over enabled)
 }
 
+/**
+ * Session lifetime configuration.
+ *
+ * Read by the supervisor process, not this ConfigManager - see
+ * src/supervisor/idle-config.ts, which parses the same file directly because
+ * the supervisor stays out of the server's module graph. Declared here so the
+ * shape stays in one place and `config({ action: 'show' })` reports it.
+ */
+export interface SessionConfig {
+  /**
+   * Minutes without any traffic from the MCP client before the server is
+   * suspended: it releases its connections, Chrome instances and managed dev
+   * servers and exits, while the supervisor stays connected and spawns a
+   * fresh server on the next request (default: 120, set to 0 to disable).
+   */
+  idleSuspendMinutes: number;
+  /** How often to check the MCP client is still alive, in seconds (default: 60) */
+  clientPollSeconds: number;
+}
+
 export interface CdpToolsConfig {
   version: number;
   configLocation: 'local' | 'global';  // Where to load config from on startup
+  session: SessionConfig;
   chrome: ChromeConfig;
   portMonitoring: PortMonitoringConfig;
   replay: ReplayConfig;
@@ -238,6 +259,10 @@ export interface CdpToolsConfig {
 const DEFAULT_CONFIG: CdpToolsConfig = {
   version: 1,
   configLocation: 'local',
+  session: {
+    idleSuspendMinutes: 120,  // Suspend after 2h of client silence (0 = never)
+    clientPollSeconds: 60,    // Check the client is still alive every minute
+  },
   chrome: {
     startingDebugPort: 9222,
     inactivityTimeoutMinutes: 5,
@@ -639,6 +664,10 @@ export class ConfigManager {
     return {
       version: loaded.version ?? defaults.version,
       configLocation: loaded.configLocation ?? defaults.configLocation,
+      session: {
+        idleSuspendMinutes: loaded.session?.idleSuspendMinutes ?? defaults.session.idleSuspendMinutes,
+        clientPollSeconds: loaded.session?.clientPollSeconds ?? defaults.session.clientPollSeconds,
+      },
       chrome: {
         startingDebugPort: loaded.chrome?.startingDebugPort ?? defaults.chrome.startingDebugPort,
         inactivityTimeoutMinutes: loaded.chrome?.inactivityTimeoutMinutes ?? defaults.chrome.inactivityTimeoutMinutes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2144,6 +2144,19 @@ async function main() {
 
   // Cleanup function for graceful shutdown
   let isCleaningUp = false;
+  /**
+   * Releases everything this session privately holds: CDP connections, the
+   * Chrome instances it launched, source maps, its reserved debug port, and
+   * the in-process monitors. Everything here dies with this process anyway.
+   *
+   * Managed dev servers are deliberately NOT stopped, on any path including an
+   * idle suspend. They are shared: `servers.json` records no owner, and any
+   * session in the same directory reattaches to the same running server, so a
+   * session that stopped them on the way out could kill a dev server another
+   * window is actively using. Reaping them needs ownership, which needs a
+   * claims registry - issue #139. Until then the rule is the asymmetry:
+   * under-stopping leaks, over-stopping destroys someone's running work.
+   */
   const cleanup = async (signal: string) => {
     if (isCleaningUp) {
       return; // Prevent multiple cleanup calls
@@ -2154,6 +2167,7 @@ async function main() {
 
     try {
       if (cleanupInterval) clearInterval(cleanupInterval); // Stop periodic cleanup
+
       await connectionManager.closeAll();
       sourceMapHandler.clear();
       await chromeLauncher.kill();
@@ -2194,6 +2208,14 @@ async function main() {
   process.on('SIGINT', () => cleanup('SIGINT'));   // Ctrl+C
   process.on('SIGTERM', () => cleanup('SIGTERM')); // Graceful shutdown (systemd, Docker, etc.)
   process.on('SIGHUP', () => cleanup('SIGHUP'));   // Terminal hangup
+
+  // The supervisor's idle-suspend signal. Kept distinct from SIGTERM even
+  // though both tear down the same things today: the supervisor means
+  // something different by it (stay connected, respawn on the next request),
+  // it is what the logs show, and the claims work will give it its own
+  // teardown. (SIGUSR2 rather than SIGUSR1, which Node reserves for its own
+  // inspector.)
+  process.on('SIGUSR2', () => cleanup('SIGUSR2 (idle suspend)'));
 
   // Handle stdin close - this catches when the parent process (Claude Code) terminates
   // without sending a signal. MCP uses stdin/stdout for communication, so if stdin closes,

--- a/src/mcp-supervisor.ts
+++ b/src/mcp-supervisor.ts
@@ -10,7 +10,11 @@
  * - a crash gets auto-relaunched with backoff, instead of leaving every
  *   project's MCP connection dead until a manual /mcp reconnect;
  * - in this repo specifically, a rebuild (package.json's `postbuild` script)
- *   or a manual `kill -USR2 <pid>` restarts the real server live.
+ *   or a manual `kill -USR2 <pid>` restarts the real server live;
+ * - an idle session's server can be dropped entirely - along with its Chrome
+ *   instances, dev servers and monitor buffers - while this process keeps the
+ *   client's connection alive and respawns on the next request (issue #138);
+ * - a tree whose client is gone shuts itself down instead of living for days.
  *
  * The child script path is resolved relative to THIS file's own location
  * (__dirname), not process.cwd() - process.cwd() is this repo's root when
@@ -27,13 +31,16 @@
  * Usage: node build/mcp-supervisor.js [...extraChildArgs]
  */
 import * as path from 'path';
+import * as os from 'os';
 import { fileURLToPath } from 'url';
-import { getOutputPath } from './helpers/paths.js';
+import { getOutputPath, getConfigPath } from './helpers/paths.js';
 import { atomicWriteFile } from './atomic-write.js';
 import { ChildManager } from './supervisor/child-manager.js';
 import { RestartCoordinator } from './supervisor/restart-coordinator.js';
 import { NdjsonReader } from './supervisor/ndjson-reader.js';
 import { removeOwnPidFile } from './supervisor/pidfile.js';
+import { ClientWatcher } from './supervisor/client-watcher.js';
+import { readSupervisorSessionConfig } from './supervisor/idle-config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -51,16 +58,25 @@ async function main(): Promise<void> {
   const pidFilePath = getOutputPath('mcp-supervisor.pid');
   await atomicWriteFile(pidFilePath, String(process.pid));
 
+  // Overridable so the stress harness can watch the escalation path without
+  // sitting out the full grace period (scripts/stress-suspend.mjs).
+  const suspendGraceMs = Number(process.env.CDP_TOOLS_SUSPEND_GRACE_MS);
+
   const childManager = new ChildManager({
     execPath: process.execPath,
     scriptPath,
     extraArgs,
     cwd: process.cwd(),
+    suspendGraceMs: Number.isFinite(suspendGraceMs) && suspendGraceMs > 0 ? suspendGraceMs : undefined,
   });
 
   // Always points at the currently-running child's stdin, so writeToChild
   // routes to whichever process is actually alive right now.
   let currentChildStdin: NodeJS.WritableStream | null = null;
+
+  // Last time this session did anything at all, in either direction - what the
+  // idle-suspend timer measures against.
+  let lastActivityAt = Date.now();
 
   const coordinator: RestartCoordinator = new RestartCoordinator(
     {
@@ -72,9 +88,14 @@ async function main(): Promise<void> {
         currentChildStdin.write(line + (line.endsWith('\n') ? '' : '\n'));
       },
       writeToHost: (line) => {
+        // Traffic in either direction means the session is working, so a tool
+        // call that runs longer than the idle threshold isn't suspended the
+        // moment it finally answers.
+        lastActivityAt = Date.now();
         process.stdout.write(line.endsWith('\n') ? line : line + '\n');
       },
       killChild: () => childManager.kill(),
+      suspendChild: () => childManager.suspend(),
       spawnChild: () => spawnAndWireChild(),
       logStderr,
     },
@@ -111,8 +132,52 @@ async function main(): Promise<void> {
   process.stdin.on('data', (chunk: Buffer) => {
     hostReader.push(chunk);
     for (const line of hostReader.readAllLines()) {
+      lastActivityAt = Date.now();
       coordinator.handleHostLine(line);
     }
+  });
+
+  const sessionConfig = readSupervisorSessionConfig({
+    configPath: getConfigPath(),
+    globalConfigPath: path.join(os.homedir(), '.cdp-tools', 'config.json'),
+  });
+
+  // Suspend an idle session. The editor window this was launched from is often
+  // left open for days; without this the child sits on its Chrome instances,
+  // dev servers and monitor buffers for all of that time (issue #138). The
+  // supervisor itself stays on the host's stdio, so the connection survives
+  // and the next request spawns a fresh child.
+  let idleCheckTimer: ReturnType<typeof setInterval> | null = null;
+  if (sessionConfig.idleSuspendMinutes > 0) {
+    const idleThresholdMs = sessionConfig.idleSuspendMinutes * 60_000;
+    // Quarter of the threshold, so the suspend lands within ~25% of it, but
+    // never more often than every 5 minutes for the long thresholds that are
+    // the normal case. The 1s floor only matters for the very short thresholds
+    // used in testing.
+    const checkIntervalMs = Math.max(1_000, Math.min(idleThresholdMs / 4, 5 * 60_000));
+    logStderr(`Idle suspend after ${sessionConfig.idleSuspendMinutes} minute(s) without host activity`);
+
+    idleCheckTimer = setInterval(() => {
+      if (!childManager.isRunning()) return;
+      const idleMs = Date.now() - lastActivityAt;
+      if (idleMs < idleThresholdMs) return;
+      coordinator.suspend(`idle for ${Math.round(idleMs / 60_000)} minute(s)`);
+    }, checkIntervalMs);
+    idleCheckTimer.unref?.();
+  } else {
+    logStderr('Idle suspend disabled by config');
+  }
+
+  // Reap the whole tree when the client that launched it is gone. stdin
+  // end/close is supposed to catch that, but never fires when an `npm exec`
+  // wrapper sits in between and outlives the client still holding our pipe -
+  // which is how trees end up alive for days after their window closed.
+  const clientWatcher = new ClientWatcher({
+    pollIntervalMs: sessionConfig.clientPollSeconds * 1000,
+    logStderr,
+  });
+  clientWatcher.start(process.pid, (client) => {
+    void shutdown(`client PID ${client.pid} exited`);
   });
 
   // Manual restart trigger (also wired to package.json's `postbuild` script).
@@ -126,6 +191,8 @@ async function main(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     logStderr(`Shutting down (${reason})`);
+    clientWatcher.stop();
+    if (idleCheckTimer) clearInterval(idleCheckTimer);
     coordinator.prepareForShutdown();
     try {
       await childManager.kill();

--- a/src/supervisor/__fixtures__/test-child.mjs
+++ b/src/supervisor/__fixtures__/test-child.mjs
@@ -4,7 +4,8 @@
  *
  * argv[2] === 'ignore-sigterm': ignores SIGTERM so kill() must escalate to SIGKILL.
  * argv[2] === 'crash': exits non-zero immediately.
- * Otherwise: behaves normally (dies on SIGTERM).
+ * argv[2] === 'ignore-suspend': ignores SIGUSR2 so suspend() must escalate to kill().
+ * Otherwise: behaves normally (dies on SIGTERM, and on the SIGUSR2 suspend signal).
  */
 const mode = process.argv[2];
 
@@ -12,6 +13,14 @@ if (mode === 'ignore-sigterm') {
   process.on('SIGTERM', () => {
     // Deliberately do nothing.
   });
+}
+
+if (mode === 'ignore-suspend') {
+  process.on('SIGUSR2', () => {
+    // Deliberately do nothing - stay alive through the suspend request.
+  });
+} else {
+  process.on('SIGUSR2', () => process.exit(0));
 }
 
 if (mode === 'crash') {

--- a/src/supervisor/child-manager.test.ts
+++ b/src/supervisor/child-manager.test.ts
@@ -61,6 +61,55 @@ describe('ChildManager (real subprocess)', () => {
     expect(exitInfo.code).toBe(1);
   }, 10000);
 
+  it('suspend() signals the child and resolves once it has released and exited', async () => {
+    const manager = new ChildManager({
+      execPath: process.execPath,
+      scriptPath: FIXTURE_PATH,
+      extraArgs: [],
+      cwd: __dirname,
+      suspendGraceMs: 3000,
+    });
+
+    manager.spawn();
+    await new Promise((resolve) => setTimeout(resolve, 200)); // let its handler register
+
+    await manager.suspend();
+    expect(manager.isRunning()).toBe(false);
+  }, 10000);
+
+  it('suspend() escalates to a kill for a child that never finishes releasing', async () => {
+    const manager = new ChildManager({
+      execPath: process.execPath,
+      scriptPath: FIXTURE_PATH,
+      extraArgs: ['ignore-suspend'],
+      cwd: __dirname,
+      suspendGraceMs: 300,
+      killGraceMs: 300,
+    });
+
+    manager.spawn();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    await manager.suspend();
+    expect(manager.isRunning()).toBe(false);
+  }, 10000);
+
+  it('suspend() on an already-dead child resolves immediately without throwing', async () => {
+    const manager = new ChildManager({
+      execPath: process.execPath,
+      scriptPath: FIXTURE_PATH,
+      extraArgs: ['crash'],
+      cwd: __dirname,
+    });
+
+    await new Promise<void>((resolve) => {
+      manager.onExit(() => resolve());
+      manager.spawn();
+    });
+
+    await expect(manager.suspend()).resolves.toBeUndefined();
+  }, 10000);
+
   it('kill() on an already-dead child resolves immediately without throwing', async () => {
     const manager = new ChildManager({
       execPath: process.execPath,

--- a/src/supervisor/child-manager.ts
+++ b/src/supervisor/child-manager.ts
@@ -21,6 +21,8 @@ export interface ChildManagerOptions {
   extraArgs: string[];
   cwd: string;
   killGraceMs?: number;
+  /** How long a suspending child gets to release its resources (default: 15s). */
+  suspendGraceMs?: number;
 }
 
 export interface ChildExitInfo {
@@ -37,9 +39,11 @@ export class ChildManager {
   private child: ChildProcess | null = null;
   private onExitCallback: ((info: ChildExitInfo) => void) | null = null;
   private readonly killGraceMs: number;
+  private readonly suspendGraceMs: number;
 
   constructor(private readonly opts: ChildManagerOptions) {
     this.killGraceMs = opts.killGraceMs ?? 3000;
+    this.suspendGraceMs = opts.suspendGraceMs ?? 15000;
   }
 
   /** Registered once; fires for every child this instance ever spawns. */
@@ -70,6 +74,54 @@ export class ChildManager {
 
   isRunning(): boolean {
     return this.child !== null;
+  }
+
+  /**
+   * Ask the child to release everything it holds - Chrome, managed dev
+   * servers, monitors - and exit, resolving once it has actually gone.
+   *
+   * SIGUSR2 rather than SIGUSR1 because Node reserves SIGUSR1 for starting its
+   * own inspector, and it is sent to the child alone rather than to its
+   * process group: the point is to give the child a chance to shut its own
+   * children down in order, not to kill them out from under it. If it doesn't
+   * finish in time, kill() escalates through the usual SIGTERM/SIGKILL path.
+   */
+  async suspend(): Promise<void> {
+    const child = this.child;
+    if (!child || child.pid === undefined) {
+      return;
+    }
+
+    const exited = await new Promise<boolean>((resolve) => {
+      let settled = false;
+      const onExit = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(true);
+      };
+      child.once('exit', onExit);
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.off('exit', onExit);
+        resolve(false);
+      }, this.suspendGraceMs);
+
+      try {
+        process.kill(child.pid!, 'SIGUSR2');
+      } catch {
+        settled = true;
+        clearTimeout(timer);
+        child.off('exit', onExit);
+        resolve(false); // already gone, or unsignalable - let kill() settle it
+      }
+    });
+
+    if (!exited) {
+      await this.kill();
+    }
   }
 
   /** Kill the current child (if any) and resolve once it has actually exited. */

--- a/src/supervisor/client-watcher.test.ts
+++ b/src/supervisor/client-watcher.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ClientWatcher, resolveClientIdentity, type ProcessInfo, type ProcessProbe } from './client-watcher.js';
+
+/** Builds a probe over a fake process table: pid -> { ppid, command }. */
+function makeProbe(table: Record<number, ProcessInfo>, dead = new Set<number>()): ProcessProbe {
+  return {
+    info: (pid) => (dead.has(pid) ? null : table[pid] ?? null),
+    isAlive: (pid) => !dead.has(pid) && pid in table,
+  };
+}
+
+describe('resolveClientIdentity', () => {
+  it('finds the client through an npm exec wrapper', () => {
+    // node <- npm exec <- claude, the shape a `npx cdp-tools-mcp` launch takes
+    const probe = makeProbe({
+      100: { ppid: 200, command: '/opt/node/bin/node /path/.bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'npm exec cdp-tools-mcp@latest' },
+      300: { ppid: 400, command: 'claude' },
+      400: { ppid: 1, command: '/bin/zsh' },
+    });
+
+    expect(resolveClientIdentity(100, probe)).toEqual({ pid: 300, command: 'claude' });
+  });
+
+  it('finds the desktop app helper below the app itself', () => {
+    const probe = makeProbe({
+      100: { ppid: 200, command: 'node .bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'npm exec cdp-tools-mcp@latest' },
+      300: { ppid: 400, command: '/Applications/Claude.app/Contents/Helpers/disclaimer' },
+      400: { ppid: 1, command: '/Applications/Claude.app/Contents/MacOS/Claude' },
+    });
+
+    const client = resolveClientIdentity(100, probe);
+    expect(client?.pid).toBe(300);
+  });
+
+  it('treats an npm-installed node host as the client, not as plumbing', () => {
+    // The host itself is a node script here, so a rule that called every node
+    // process plumbing would walk past it to the shell and terminal - which
+    // outlive the client, leaving the tree unreaped.
+    const probe = makeProbe({
+      100: { ppid: 200, command: 'node /Users/x/.npm/_npx/abc/node_modules/.bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'npm exec cdp-tools-mcp@latest' },
+      300: { ppid: 400, command: 'node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js' },
+      400: { ppid: 500, command: '/bin/zsh -l' },
+      500: { ppid: 1, command: '/Applications/iTerm.app/Contents/MacOS/iTerm2' },
+    });
+
+    expect(resolveClientIdentity(100, probe)?.pid).toBe(300);
+  });
+
+  it('still walks past npm and npx machinery running under node', () => {
+    const probe = makeProbe({
+      100: { ppid: 200, command: 'node /path/node_modules/.bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js exec' },
+      300: { ppid: 1, command: 'claude' },
+    });
+
+    expect(resolveClientIdentity(100, probe)?.pid).toBe(300);
+  });
+
+  it('treats a bare runtime with no script as plumbing', () => {
+    const probe = makeProbe({
+      100: { ppid: 200, command: 'node /path/.bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'node' },
+      300: { ppid: 1, command: 'code-helper' },
+    });
+
+    expect(resolveClientIdentity(100, probe)?.pid).toBe(300);
+  });
+
+  it('returns null when every ancestor is launch plumbing', () => {
+    const probe = makeProbe({
+      100: { ppid: 200, command: 'node /path/node_modules/.bin/cdp-tools-mcp' },
+      200: { ppid: 300, command: 'npm exec cdp-tools-mcp@latest' },
+      300: { ppid: 1, command: '/bin/bash' },
+    });
+
+    expect(resolveClientIdentity(100, probe)).toBeNull();
+  });
+
+  it('returns null when the ancestry is unreadable', () => {
+    expect(resolveClientIdentity(100, makeProbe({}))).toBeNull();
+  });
+
+  it('gives up rather than looping on a deep ancestry', () => {
+    // Every entry is plumbing, so a bounded walk is the only thing that stops it.
+    const table: Record<number, ProcessInfo> = {};
+    for (let pid = 100; pid < 200; pid++) {
+      table[pid] = { ppid: pid + 1, command: 'npm exec something' };
+    }
+    expect(resolveClientIdentity(100, makeProbe(table), 5)).toBeNull();
+  });
+});
+
+describe('ClientWatcher', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const TABLE: Record<number, ProcessInfo> = {
+    100: { ppid: 200, command: 'node .bin/cdp-tools-mcp' },
+    200: { ppid: 300, command: 'npm exec cdp-tools-mcp@latest' },
+    300: { ppid: 1, command: 'claude' },
+  };
+
+  it('calls back once the client is gone', () => {
+    const dead = new Set<number>();
+    const watcher = new ClientWatcher({ pollIntervalMs: 1000, probe: makeProbe(TABLE, dead) });
+    const onGone = vi.fn();
+
+    expect(watcher.start(100, onGone)).toEqual({ pid: 300, command: 'claude' });
+
+    vi.advanceTimersByTime(3000);
+    expect(onGone).not.toHaveBeenCalled();
+
+    dead.add(300);
+    vi.advanceTimersByTime(1000);
+    expect(onGone).toHaveBeenCalledTimes(1);
+    expect(onGone).toHaveBeenCalledWith({ pid: 300, command: 'claude' });
+
+    // Stops polling after firing - one shutdown is enough.
+    vi.advanceTimersByTime(10_000);
+    expect(onGone).toHaveBeenCalledTimes(1);
+  });
+
+  it('watches nothing when no client can be identified', () => {
+    const watcher = new ClientWatcher({ pollIntervalMs: 1000, probe: makeProbe({}) });
+    const onGone = vi.fn();
+
+    expect(watcher.start(100, onGone)).toBeNull();
+    vi.advanceTimersByTime(60_000);
+    expect(onGone).not.toHaveBeenCalled();
+  });
+
+  it('stops polling when stopped', () => {
+    const dead = new Set<number>();
+    const watcher = new ClientWatcher({ pollIntervalMs: 1000, probe: makeProbe(TABLE, dead) });
+    const onGone = vi.fn();
+
+    watcher.start(100, onGone);
+    watcher.stop();
+    dead.add(300);
+
+    vi.advanceTimersByTime(10_000);
+    expect(onGone).not.toHaveBeenCalled();
+  });
+});

--- a/src/supervisor/client-watcher.ts
+++ b/src/supervisor/client-watcher.ts
@@ -1,0 +1,220 @@
+/**
+ * Watches the MCP client (Claude Code, the Claude desktop app, an IDE) that
+ * this supervisor was launched to serve, and reports when it is gone.
+ *
+ * WHY THIS EXISTS
+ * The supervisor already shuts down on stdin end/close, which is supposed to
+ * catch a client that dies without signalling. It does not fire when the
+ * client was launched through `npx`: the `npm exec` wrapper sits between the
+ * client and this process, survives the client's death (reparented to init),
+ * and keeps holding the write end of our stdin pipe. No EOF ever arrives, so
+ * the whole tree - supervisor, real server, its Chrome and dev servers - lives
+ * on for days holding memory nobody is asking it to hold (issue #138).
+ *
+ * So instead of waiting to be told, we find out who the client actually is and
+ * check whether it is still alive.
+ *
+ * FINDING THE CLIENT
+ * Walk up the process ancestry from this process and take the first ancestor
+ * that isn't part of the launch plumbing - Node itself, npm/npx, a shell. For
+ * the three shapes seen in the wild that lands on:
+ *   node <- npm exec <- claude                          => claude
+ *   node <- npm exec <- disclaimer <- Claude.app         => disclaimer (the
+ *       Claude app's own helper - it dies with the app, which is what matters)
+ *   node <- code helper                                  => the IDE helper
+ *
+ * If the walk finds nothing but plumbing all the way to pid 1, there is no
+ * client to watch and reaping is disabled - better to leak than to kill a tree
+ * that is still serving someone.
+ */
+import { execFileSync } from 'child_process';
+
+export interface ProcessInfo {
+  ppid: number;
+  command: string;
+}
+
+export interface ProcessProbe {
+  /** Parent pid + command for a pid, or null if the pid is gone/unreadable. */
+  info(pid: number): ProcessInfo | null;
+  /** Whether the pid still exists. */
+  isAlive(pid: number): boolean;
+}
+
+export interface ClientIdentity {
+  pid: number;
+  command: string;
+}
+
+/**
+ * Package managers and shells that are only ever launch plumbing, never the
+ * client itself. Matched against the command's leading token's basename.
+ */
+const PLUMBING = new Set([
+  'npm',
+  'npx',
+  'pnpm',
+  'yarn',
+  'bunx',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'dash',
+  'ksh',
+  'env',
+  'exec',
+  'login',
+]);
+
+/** Runtimes that are plumbing or client depending on what they are running. */
+const RUNTIMES = new Set(['node', 'node.exe', 'nodejs', 'bun', 'deno']);
+
+/**
+ * Scripts that mean a runtime process is npm/npx machinery rather than the
+ * client. Anything else a runtime is running is treated as the client itself:
+ * an npm-installed MCP host appears in `ps` as `node .../cli.js`, and calling
+ * every node process plumbing would walk straight past it to the user's shell
+ * and terminal - which live for weeks, so the tree would never be reaped.
+ */
+const RUNTIME_PLUMBING_SCRIPTS = [
+  'npm-cli.js',
+  'npx-cli.js',
+  'npm-prefix.js',
+  '/node_modules/.bin/',
+  '/npm/bin/',
+  '/_npx/',
+  '/corepack/',
+];
+
+function isPlumbing(command: string): boolean {
+  const tokens = command.trim().split(/\s+/);
+  const basename = (tokens[0] ?? '').split('/').pop() ?? '';
+
+  if (PLUMBING.has(basename)) return true;
+
+  if (RUNTIMES.has(basename)) {
+    // A bare runtime with no script (a REPL, or an unreadable command) tells
+    // us nothing; treat it as plumbing, as before.
+    const script = tokens.slice(1).find((token) => !token.startsWith('-'));
+    if (!script) return true;
+    return RUNTIME_PLUMBING_SCRIPTS.some((marker) => script.includes(marker));
+  }
+
+  return false;
+}
+
+/** Reads process info via `ps`. Unavailable on Windows, which has no `ps`. */
+export const systemProcessProbe: ProcessProbe = {
+  info(pid: number): ProcessInfo | null {
+    try {
+      const out = execFileSync('ps', ['-o', 'ppid=,command=', '-p', String(pid)], {
+        encoding: 'utf-8',
+        timeout: 2000,
+      }).trim();
+      if (!out) return null;
+      const match = out.match(/^\s*(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return { ppid: Number(match[1]), command: match[2] };
+    } catch {
+      return null;
+    }
+  },
+  isAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      // EPERM means it exists but belongs to another user - still alive.
+      return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+    }
+  },
+};
+
+/**
+ * Walk up from `startPid`'s parent and return the first ancestor that isn't
+ * launch plumbing, or null if there is none.
+ */
+export function resolveClientIdentity(
+  startPid: number,
+  probe: ProcessProbe,
+  maxDepth = 12
+): ClientIdentity | null {
+  let current = probe.info(startPid);
+  for (let depth = 0; depth < maxDepth; depth++) {
+    if (!current || current.ppid <= 1) return null;
+    const parent = probe.info(current.ppid);
+    if (!parent) return null;
+    if (!isPlumbing(parent.command)) {
+      return { pid: current.ppid, command: parent.command };
+    }
+    current = { ppid: parent.ppid, command: parent.command };
+  }
+  return null;
+}
+
+export interface ClientWatcherOptions {
+  /** How often to check the client is still alive (default: 60s). */
+  pollIntervalMs?: number;
+  probe?: ProcessProbe;
+  logStderr?: (message: string) => void;
+}
+
+/**
+ * Polls the resolved client's liveness and calls back once, when it dies.
+ * Does nothing at all when no client could be resolved.
+ */
+export class ClientWatcher {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly probe: ProcessProbe;
+  private readonly pollIntervalMs: number;
+  private readonly logStderr: (message: string) => void;
+  private client: ClientIdentity | null = null;
+
+  constructor(private readonly options: ClientWatcherOptions = {}) {
+    this.probe = options.probe ?? systemProcessProbe;
+    this.pollIntervalMs = options.pollIntervalMs ?? 60_000;
+    this.logStderr = options.logStderr ?? (() => {});
+  }
+
+  getClient(): ClientIdentity | null {
+    return this.client;
+  }
+
+  /**
+   * Resolve the client and start watching. Returns the client it will watch,
+   * or null if none could be resolved (in which case nothing is watched).
+   */
+  start(startPid: number, onClientGone: (client: ClientIdentity) => void): ClientIdentity | null {
+    if (process.platform === 'win32') {
+      this.logStderr('Client watcher disabled on Windows (no ps); relying on stdin close');
+      return null;
+    }
+
+    this.client = resolveClientIdentity(startPid, this.probe);
+    if (!this.client) {
+      this.logStderr('Could not identify the MCP client process; orphan reaping disabled');
+      return null;
+    }
+
+    const client = this.client;
+    this.logStderr(`Watching client PID ${client.pid} (${client.command.slice(0, 80)})`);
+
+    this.timer = setInterval(() => {
+      if (this.probe.isAlive(client.pid)) return;
+      this.stop();
+      this.logStderr(`Client PID ${client.pid} is gone; shutting down`);
+      onClientGone(client);
+    }, this.pollIntervalMs);
+    this.timer.unref?.();
+
+    return client;
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/supervisor/idle-config.test.ts
+++ b/src/supervisor/idle-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  readSupervisorSessionConfig,
+  DEFAULT_IDLE_SUSPEND_MINUTES,
+  DEFAULT_CLIENT_POLL_SECONDS,
+} from './idle-config.js';
+
+const NO_FILE = () => {
+  throw new Error('ENOENT');
+};
+
+describe('readSupervisorSessionConfig', () => {
+  it('falls back to defaults with no config file', () => {
+    const config = readSupervisorSessionConfig({ configPath: '/nope.json', env: {}, readFile: NO_FILE });
+    expect(config).toEqual({
+      idleSuspendMinutes: DEFAULT_IDLE_SUSPEND_MINUTES,
+      clientPollSeconds: DEFAULT_CLIENT_POLL_SECONDS,
+    });
+  });
+
+  it('reads the session section from the config file', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: {},
+      readFile: () => JSON.stringify({ session: { idleSuspendMinutes: 30, clientPollSeconds: 15 } }),
+    });
+    expect(config).toEqual({ idleSuspendMinutes: 30, clientPollSeconds: 15 });
+  });
+
+  it('lets the environment override the file', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: { CDP_TOOLS_IDLE_SUSPEND_MINUTES: '5' },
+      readFile: () => JSON.stringify({ session: { idleSuspendMinutes: 30 } }),
+    });
+    expect(config.idleSuspendMinutes).toBe(5);
+  });
+
+  it('keeps 0 as an explicit "never suspend"', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: {},
+      readFile: () => JSON.stringify({ session: { idleSuspendMinutes: 0 } }),
+    });
+    expect(config.idleSuspendMinutes).toBe(0);
+  });
+
+  it('ignores a zero or negative poll interval rather than spinning', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: {},
+      readFile: () => JSON.stringify({ session: { clientPollSeconds: 0 } }),
+    });
+    expect(config.clientPollSeconds).toBe(DEFAULT_CLIENT_POLL_SECONDS);
+  });
+
+  it('falls back to defaults on a corrupt config file', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: {},
+      readFile: () => '{ not json',
+    });
+    expect(config.idleSuspendMinutes).toBe(DEFAULT_IDLE_SUSPEND_MINUTES);
+  });
+
+  it('ignores non-numeric values', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/config.json',
+      env: { CDP_TOOLS_IDLE_SUSPEND_MINUTES: 'soon' },
+      readFile: () => JSON.stringify({ session: { idleSuspendMinutes: 'later' } }),
+    });
+    expect(config.idleSuspendMinutes).toBe(DEFAULT_IDLE_SUSPEND_MINUTES);
+  });
+});
+
+describe('readSupervisorSessionConfig - global config', () => {
+  it('follows configLocation global when the local file is only a stub', () => {
+    // `config({ action: 'useGlobal' })` leaves exactly this stub behind, and
+    // getConfigPath() returns it because it exists.
+    const files: Record<string, string> = {
+      '/local.json': JSON.stringify({ configLocation: 'global' }),
+      '/global.json': JSON.stringify({ session: { idleSuspendMinutes: 0 } }),
+    };
+    const config = readSupervisorSessionConfig({
+      configPath: '/local.json',
+      globalConfigPath: '/global.json',
+      env: {},
+      readFile: (path) => files[path] ?? (() => { throw new Error('ENOENT'); })(),
+    });
+    expect(config.idleSuspendMinutes).toBe(0);
+  });
+
+  it('prefers a local session section over the global file', () => {
+    const files: Record<string, string> = {
+      '/local.json': JSON.stringify({ configLocation: 'global', session: { idleSuspendMinutes: 45 } }),
+      '/global.json': JSON.stringify({ session: { idleSuspendMinutes: 5 } }),
+    };
+    const config = readSupervisorSessionConfig({
+      configPath: '/local.json',
+      globalConfigPath: '/global.json',
+      env: {},
+      readFile: (path) => files[path],
+    });
+    expect(config.idleSuspendMinutes).toBe(45);
+  });
+
+  it('treats an empty env var as unset rather than as "never suspend"', () => {
+    const config = readSupervisorSessionConfig({
+      configPath: '/nope.json',
+      env: { CDP_TOOLS_IDLE_SUSPEND_MINUTES: '' },
+      readFile: () => { throw new Error('ENOENT'); },
+    });
+    expect(config.idleSuspendMinutes).toBe(DEFAULT_IDLE_SUSPEND_MINUTES);
+  });
+});

--- a/src/supervisor/idle-config.ts
+++ b/src/supervisor/idle-config.ts
@@ -1,0 +1,83 @@
+/**
+ * Reads the idle-suspend settings for the supervisor.
+ *
+ * The supervisor runs before (and outlives) the real server, and deliberately
+ * stays free of the server's module graph - so it cannot use ConfigManager,
+ * which loads Zod, the debug logger and everything downstream of them. It
+ * reads the same `.cdp-tools/config.json` directly instead, and falls back to
+ * the shipped defaults on anything unreadable.
+ *
+ * Precedence: env var > config file > default.
+ */
+import { readFileSync } from 'fs';
+
+export const DEFAULT_IDLE_SUSPEND_MINUTES = 120;
+export const DEFAULT_CLIENT_POLL_SECONDS = 60;
+
+export interface SupervisorSessionConfig {
+  /** Minutes of host silence before the child is suspended. 0 disables it. */
+  idleSuspendMinutes: number;
+  /** How often to check the MCP client is still alive. */
+  clientPollSeconds: number;
+}
+
+function readNumber(value: unknown): number | null {
+  // `Number('')` is 0, which would read as a deliberate "never suspend" - an
+  // empty exported env var is an accident, not a setting.
+  if (typeof value === 'string' && value.trim() === '') return null;
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  if (typeof parsed !== 'number' || !Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export interface ReadSessionConfigDeps {
+  /** Path to config.json, as resolved by getConfigPath(). */
+  configPath: string;
+  /** Path to ~/.cdp-tools/config.json, followed when the local file defers to it. */
+  globalConfigPath?: string;
+  env?: NodeJS.ProcessEnv;
+  readFile?: (path: string) => string;
+}
+
+export function readSupervisorSessionConfig(deps: ReadSessionConfigDeps): SupervisorSessionConfig {
+  const env = deps.env ?? process.env;
+  const read = deps.readFile ?? ((p: string) => readFileSync(p, 'utf-8'));
+
+  const readSession = (path: string): { session: Record<string, unknown> | null; deferred: boolean } => {
+    try {
+      const parsed = JSON.parse(read(path));
+      if (!parsed || typeof parsed !== 'object') return { session: null, deferred: false };
+      const session = typeof parsed.session === 'object' && parsed.session ? (parsed.session as Record<string, unknown>) : null;
+      return { session, deferred: parsed.configLocation === 'global' };
+    } catch {
+      // No config file yet, or unreadable/corrupt - defaults are fine.
+      return { session: null, deferred: false };
+    }
+  };
+
+  const local = readSession(deps.configPath);
+  let fromFile = local.session ?? {};
+  // `config({ action: 'useGlobal' })` leaves a local stub holding nothing but
+  // `configLocation: 'global'`, and getConfigPath() returns that stub because
+  // it exists. Reading only it would silently ignore the settings the user
+  // actually wrote, in the file the config tool shows them.
+  if (local.deferred && !local.session && deps.globalConfigPath) {
+    fromFile = readSession(deps.globalConfigPath).session ?? {};
+  }
+
+  const idleSuspendMinutes =
+    readNumber(env.CDP_TOOLS_IDLE_SUSPEND_MINUTES) ??
+    readNumber(fromFile.idleSuspendMinutes) ??
+    DEFAULT_IDLE_SUSPEND_MINUTES;
+
+  const clientPollSeconds =
+    readNumber(env.CDP_TOOLS_CLIENT_POLL_SECONDS) ??
+    readNumber(fromFile.clientPollSeconds) ??
+    DEFAULT_CLIENT_POLL_SECONDS;
+
+  return {
+    idleSuspendMinutes,
+    // A zero poll interval would spin; treat it as "use the default".
+    clientPollSeconds: clientPollSeconds > 0 ? clientPollSeconds : DEFAULT_CLIENT_POLL_SECONDS,
+  };
+}

--- a/src/supervisor/restart-coordinator.test.ts
+++ b/src/supervisor/restart-coordinator.test.ts
@@ -328,6 +328,48 @@ describe('RestartCoordinator - onChildExit (crash) vs deliberate restart', () =>
   });
 });
 
+describe('RestartCoordinator - cancelled requests', () => {
+  it('stops awaiting a cancelled request, so idle suspend is not blocked forever', async () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+
+    coordinator.handleHostLine('{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{}}');
+    // MCP forbids answering a cancelled request, so no response will ever come.
+    coordinator.handleHostLine('{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":9}}');
+
+    coordinator.suspend('idle');
+    await flushPromises();
+
+    expect(deps.suspendChild).toHaveBeenCalledTimes(1);
+    expect(coordinator.getPhase()).toBe('suspended');
+  });
+
+  it('swallows a late response to a cancelled request', () => {
+    const deps = makeDeps();
+    const coordinator = new RestartCoordinator(deps);
+
+    coordinator.handleHostLine('{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{}}');
+    coordinator.handleHostLine('{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":9}}');
+    deps.hostLines.length = 0;
+
+    coordinator.handleChildLine('{"jsonrpc":"2.0","id":9,"result":{}}');
+    expect(deps.hostLines).toEqual([]);
+  });
+
+  it('still blocks suspend for requests that were not cancelled', () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+
+    coordinator.handleHostLine('{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{}}');
+    coordinator.handleHostLine('{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":10}}');
+
+    coordinator.suspend('idle');
+    expect(deps.suspendChild).not.toHaveBeenCalled();
+  });
+});
+
 // Real timers, so `.then()` chains attached to already-resolved/pending native
 // Promises actually get a chance to run.
 async function flushMicrotasks(): Promise<void> {
@@ -339,3 +381,152 @@ async function flushMicrotasks(): Promise<void> {
 async function flushPromises(): Promise<void> {
   await flushMicrotasks();
 }
+
+describe('RestartCoordinator - idle suspend', () => {
+  const TOOL_CALL = '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{}}';
+
+  async function handshake(deps: ReturnType<typeof makeDeps>, coordinator: RestartCoordinator) {
+    coordinator.handleHostLine(INIT_REQUEST);
+    coordinator.handleHostLine(INITIALIZED_NOTIF);
+    coordinator.handleChildLine('{"jsonrpc":"2.0","id":1,"result":{}}');
+    deps.childLines.length = 0;
+    deps.hostLines.length = 0;
+  }
+
+  it('tears the child down and stays suspended until the host speaks again', async () => {
+    const deps = makeDeps();
+    const suspendChild = vi.fn().mockResolvedValue(undefined);
+    deps.suspendChild = suspendChild;
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle for 120 minute(s)');
+    expect(suspendChild).toHaveBeenCalledTimes(1);
+    await flushPromises();
+    expect(coordinator.getPhase()).toBe('suspended');
+    expect(deps.spawnChild).not.toHaveBeenCalled();
+  });
+
+  it('respawns and replays the handshake on the next host line', async () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    await flushPromises();
+
+    coordinator.handleHostLine(TOOL_CALL);
+
+    expect(deps.spawnChild).toHaveBeenCalledTimes(1);
+    expect(coordinator.getPhase()).toBe('ready');
+    // Replayed handshake first, then the request that woke us - and the
+    // request is forwarded rather than answered with an error.
+    expect(deps.childLines).toEqual([INIT_REQUEST, INITIALIZED_NOTIF, TOOL_CALL]);
+    expect(deps.hostLines.every((line) => !line.includes('"error"'))).toBe(true);
+  });
+
+  it('swallows the replayed initialize response the host already has', async () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    await flushPromises();
+    coordinator.handleHostLine(TOOL_CALL);
+
+    coordinator.handleChildLine('{"jsonrpc":"2.0","id":1,"result":{}}');
+    expect(deps.hostLines.some((line) => JSON.parse(line).id === 1)).toBe(false);
+
+    coordinator.handleChildLine('{"jsonrpc":"2.0","id":9,"result":{}}');
+    expect(JSON.parse(deps.hostLines.at(-1)!)).toMatchObject({ id: 9 });
+  });
+
+  it('queues a request that arrives while the child is still exiting', async () => {
+    const deps = makeDeps();
+    let releaseTeardown: () => void = () => {};
+    deps.suspendChild = vi.fn(() => new Promise<void>((resolve) => { releaseTeardown = resolve; }));
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    expect(coordinator.getPhase()).toBe('suspending');
+
+    coordinator.handleHostLine(TOOL_CALL);
+    // Nothing spawned yet - two children must never be alive at once.
+    expect(deps.spawnChild).not.toHaveBeenCalled();
+    expect(deps.hostLines).toEqual([]);
+
+    releaseTeardown();
+    await flushPromises();
+
+    expect(deps.spawnChild).toHaveBeenCalledTimes(1);
+    expect(deps.childLines).toContain(TOOL_CALL);
+  });
+
+  it('refuses to suspend with a request in flight', () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+    coordinator.handleHostLine(TOOL_CALL);
+
+    coordinator.suspend('idle');
+
+    expect(deps.suspendChild).not.toHaveBeenCalled();
+    expect(coordinator.getPhase()).toBe('ready');
+  });
+
+  it('refuses to suspend while restarting', () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+    coordinator.requestRestart('signal');
+
+    coordinator.suspend('idle');
+
+    expect(deps.suspendChild).not.toHaveBeenCalled();
+  });
+
+  it('ignores a restart trigger while suspended, leaving the next request to spawn a fresh build', async () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn().mockResolvedValue(undefined);
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    await flushPromises();
+
+    coordinator.requestRestart('signal');
+    await flushPromises();
+
+    expect(deps.killChild).not.toHaveBeenCalled();
+    expect(deps.spawnChild).not.toHaveBeenCalled();
+    expect(coordinator.getPhase()).toBe('suspended');
+  });
+
+  it('does not treat the suspended child\'s exit as a crash', async () => {
+    const deps = makeDeps();
+    deps.suspendChild = vi.fn(async () => { coordinator.onChildExit(); });
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    await flushPromises();
+
+    expect(deps.spawnChild).not.toHaveBeenCalled();
+    expect(coordinator.getPhase()).toBe('suspended');
+  });
+
+  it('falls back to killChild when no suspendChild is wired', async () => {
+    const deps = makeDeps();
+    const coordinator = new RestartCoordinator(deps);
+    await handshake(deps, coordinator);
+
+    coordinator.suspend('idle');
+    await flushPromises();
+
+    expect(deps.killChild).toHaveBeenCalledTimes(1);
+    expect(coordinator.getPhase()).toBe('suspended');
+  });
+});

--- a/src/supervisor/restart-coordinator.ts
+++ b/src/supervisor/restart-coordinator.ts
@@ -15,15 +15,23 @@
  *   child (deliberate restart or crash), so the host never hangs waiting
  *   for an answer that will never arrive.
  * - Back off and eventually give up on repeated unplanned crashes.
+ * - Suspend an idle session: let the child (and everything it holds - Chrome,
+ *   dev servers, monitor buffers) go, while this supervisor stays resident on
+ *   the host's stdio, and bring a fresh child back on the next host line.
  */
 import { classifyLine, serializeMessage } from './ndjson-reader.js';
 
-export type SupervisorPhase = 'ready' | 'restarting' | 'idle-gave-up';
+export type SupervisorPhase = 'ready' | 'restarting' | 'idle-gave-up' | 'suspending' | 'suspended';
 
 export interface RestartCoordinatorDeps {
   writeToChild: (line: string) => void;
   writeToHost: (line: string) => void;
   killChild: () => Promise<void>;
+  /**
+   * Ask the child to release everything it holds and exit - a deeper teardown
+   * than killChild(), which leaves managed dev servers running.
+   */
+  suspendChild?: () => Promise<void>;
   spawnChild: () => void;
   logStderr: (message: string) => void;
 }
@@ -54,6 +62,8 @@ export class RestartCoordinator {
 
   private inFlight = new Map<string | number, { method: string }>();
   private abandonedIds = new Set<string | number>();
+  /** Host lines that arrived while the suspending child was still exiting. */
+  private suspendQueue: string[] = [];
 
   private expectingExit = false;
   private crashAttempt = 0;
@@ -80,6 +90,23 @@ export class RestartCoordinator {
   handleHostLine(line: string): void {
     const parsed = classifyLine(line);
 
+    // A line that lands while the old child is still going down waits for it:
+    // spawning a replacement now would leave two children alive at once, and
+    // erroring the request would punish the user for the timing of their own
+    // first call back.
+    if (this.phase === 'suspending') {
+      this.suspendQueue.push(line);
+      return;
+    }
+
+    // Any traffic at all means the session is alive again - bring the child
+    // back before handling the line, so this very request is the one that
+    // resumes us rather than the one that gets an error.
+    if (this.phase === 'suspended') {
+      this.deps.logStderr('Host activity after suspend; respawning child');
+      this.spawnAndReplay();
+    }
+
     if (this.phase !== 'ready') {
       if (parsed.kind === 'request') {
         this.sendSynthesizedError(parsed.id);
@@ -102,6 +129,19 @@ export class RestartCoordinator {
       parsed.method === 'notifications/initialized'
     ) {
       this.initializedLine = line;
+    }
+
+    // A cancelled request never gets a response - MCP forbids answering one -
+    // so its id would sit in `inFlight` forever, and since suspend refuses to
+    // run with anything in flight, one Esc during a long tool call would
+    // silently disable idle suspend for the rest of the session.
+    if (parsed.kind === 'notification' && parsed.method === 'notifications/cancelled') {
+      const cancelledId = (parsed.raw as { params?: { requestId?: string | number } })?.params?.requestId;
+      if (cancelledId !== undefined && this.inFlight.delete(cancelledId)) {
+        // Should a late response arrive anyway, swallow it: the host has moved on.
+        this.abandonedIds.add(cancelledId);
+        this.deps.logStderr(`Host cancelled request ${cancelledId}; no longer awaiting a response`);
+      }
     }
 
     // The captured init request's lifecycle is managed separately (via
@@ -190,6 +230,13 @@ export class RestartCoordinator {
       this.deps.logStderr(`Restart already in progress, ignoring additional trigger (${reason})`);
       return;
     }
+    if (this.phase === 'suspending' || this.phase === 'suspended') {
+      // Nothing is running to restart, and the next host line will spawn a
+      // child from whatever is on disk by then - which for a rebuild trigger
+      // is exactly the new build.
+      this.deps.logStderr(`Suspended, so ignoring restart trigger (${reason}); next request spawns a fresh child`);
+      return;
+    }
     if (this.phase === 'idle-gave-up') {
       this.crashAttempt = 0;
     }
@@ -209,6 +256,47 @@ export class RestartCoordinator {
       .then(() => {
         this.expectingExit = false;
         this.spawnAndReplay();
+      });
+  }
+
+  /**
+   * Idle timeout reached: drop the child and everything it holds, and stay
+   * resident on the host's stdio so the connection itself survives. The next
+   * host line respawns via handleHostLine().
+   *
+   * Only ever suspends from a settled 'ready' state - suspending mid-restart
+   * or while the crash backoff is deciding what to do would race with it.
+   */
+  suspend(reason: string): void {
+    if (this.phase !== 'ready') {
+      this.deps.logStderr(`Not suspending while phase=${this.phase}`);
+      return;
+    }
+    if (this.inFlight.size > 0) {
+      this.deps.logStderr(`Not suspending with ${this.inFlight.size} request(s) in flight`);
+      return;
+    }
+
+    this.deps.logStderr(`Suspending idle child (${reason})`);
+    this.clearStabilityTimer();
+    this.phase = 'suspending';
+    this.expectingExit = true;
+
+    const teardown = this.deps.suspendChild ?? this.deps.killChild;
+    teardown()
+      .catch((err) => this.deps.logStderr(`suspendChild() failed (continuing anyway): ${err}`))
+      .then(() => {
+        // No child is running now, so nothing is left to report an exit we
+        // would have to distinguish from a crash.
+        this.expectingExit = false;
+        this.crashAttempt = 0;
+        this.phase = 'suspended';
+
+        const queued = this.suspendQueue;
+        this.suspendQueue = [];
+        for (const queuedLine of queued) {
+          this.handleHostLine(queuedLine);
+        }
       });
   }
 


### PR DESCRIPTION
Closes #138.

Measured on one machine mid-session, before any of this:

```
cdp-tools total: 506MB across 61 procs
22 supervisor trees, oldest up 11 days
chrome total: 102MB across 8 procs
```

The bulk is stale server trees, not browsers. Two causes.

## A tree outlives its client

`mcp-supervisor.ts` shuts down on stdin `end`/`close`, which is supposed to catch a client that dies without signalling. Walking the ancestry of one of the surviving trees shows why it never fired:

```
26723 26574 node                       <- supervisor
26574     1 npm exec cdp-tools-mcp@latest
ROOT=launchd (orphaned)
```

`lsof` shows fd 0 still an open PIPE. The client is long gone, but the `npm exec` wrapper in between survived it and still holds the write end, so no EOF ever arrives. Reparenting to launchd is the only visible evidence and nothing was watching for it.

`ClientWatcher` now resolves the real client at startup - the nearest ancestor that is not node/npm/npx/a shell - and polls it with `kill(pid, 0)`. A runtime counts as plumbing only when it is running npm/npx machinery: an npm-installed host appears as `node .../cli.js`, and treating every node process as plumbing would walk past it to the user's shell and terminal, which live for weeks. That would have looked healthy in the logs while reaping silently never fired.

## A live session holds everything while idle

After `session.idleSuspendMinutes` (default 120) with no traffic in either direction, the child is torn down and the supervisor stays resident on the client's stdio. The MCP connection survives; the next request spawns a fresh child and replays the captured `initialize` + `notifications/initialized`.

`RestartCoordinator` gains `suspending`/`suspended` phases rather than a second mechanism beside the hot-reload one it already had. Two invariants it has to hold:

- a request arriving mid-teardown is **queued**, not spawned against - two children must never be alive at once;
- a **cancelled** request is pruned from the in-flight map. MCP forbids answering one, so a stuck entry would sit in `inFlight` forever and, since suspend refuses to run with anything in flight, one Esc during a tool call would silently disable the feature for the rest of the session.

## Dev servers are deliberately not stopped

On every path, including suspend. They are shared: `servers.json` records no owner and any session in the directory reattaches to the same running server, so stopping them on the way out can kill a server another window is actively using - and for a Compose runner it can take down containers belonging to tooling outside cdp-tools entirely.

Doing this correctly needs ownership, which needs a claims registry: #139. Until then the rule is the asymmetry - under-stopping leaks, over-stopping destroys running work. The `release` stress scenario asserts the dev server is **still listening** after a suspend, so a regression back to stopping them fails the harness.

## Config

```json
{ "session": { "idleSuspendMinutes": 120, "clientPollSeconds": 60 } }
```

`0` disables suspend. `CDP_TOOLS_IDLE_SUSPEND_MINUTES` / `CDP_TOOLS_CLIENT_POLL_SECONDS` override the file. Read by the supervisor at startup rather than hot-reloaded, since the supervisor stays out of the server's module graph - documented, and it follows `configLocation: 'global'` so a global setting is not silently ignored.

## Verification

`npm run stress:suspend` drives the built supervisor as a real process, with real signals and real timing - the failures worth catching here are ones fakes cannot show you. Sub-minute thresholds via fractional minutes, so the 2h default never has to be waited out.

```
race        PASS  requests aimed across the teardown window, max children 1
leak        PASS  RSS flat, 37 fd flat across 40 cycles
release     PASS  Chrome released, shared dev server left running
signals     PASS  rebuild / shutdown / child SIGKILL during teardown
escalation  PASS  SIGUSR2-ignoring child + grandchild killed, then resumed
reaper      PASS  6 trees / 12 processes reaped 201ms after the client died
```

Plus 760 unit tests and `tsc --noEmit` clean. The harness is outside `npm test` - it spawns dozens of processes and takes minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GZ1d3854DTRq7h1Rx3dpm
